### PR TITLE
Code Scanning設定: Python+シェルスクリプトセキュリティ監視

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,210 @@
+---
+# CodeQLセキュリティスキャンワークフロー（Python + シェルスクリプト対応）
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # 毎週月曜日の午前2時（UTC）に実行
+    - cron: '0 2 * * 1'
+
+jobs:
+  analyze:
+    name: CodeQL分析
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: CodeQLを初期化
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # より多くの脆弱性を検出するためにdefault以上のクエリを実行
+          queries: security-extended,security-and-quality
+
+      - name: 自動ビルド
+        uses: github/codeql-action/autobuild@v3
+
+      - name: CodeQL分析を実行
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"
+
+  shell-security-scan:
+    name: シェルスクリプトセキュリティスキャン
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: uvのセットアップ
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
+      - name: 依存関係のインストール
+        run: uv sync
+
+      - name: ShellCheckを実行してSARIF形式で出力
+        run: |
+          # シェルスクリプトファイルを検索
+          find . -name "*.sh" -o -name "*.bash" > shell_files.txt
+          
+          if [ -s shell_files.txt ]; then
+            # ShellCheckをSARIF形式で実行
+            uv run shellcheck --rcfile=config/.shellcheckrc \
+              --format=json $(cat shell_files.txt) > shellcheck-results.json || true
+            
+            # JSON結果をSARIF形式に変換
+            cat > convert_to_sarif.py << 'EOF'
+import json
+import sys
+from datetime import datetime
+
+def convert_shellcheck_to_sarif(input_file, output_file):
+    """ShellCheckのJSON出力をSARIF 2.1.0形式に変換"""
+    try:
+        with open(input_file, 'r') as f:
+            shellcheck_results = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        shellcheck_results = []
+    
+    sarif_report = {
+        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+        "version": "2.1.0",
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": "ShellCheck",
+                        "version": "0.10.0",
+                        "informationUri": "https://github.com/koalaman/shellcheck",
+                        "semanticVersion": "0.10.0",
+                        "rules": []
+                    }
+                },
+                "results": [],
+                "columnKind": "utf16CodeUnits"
+            }
+        ]
+    }
+    
+    # ルールとアラートを処理
+    rules_map = {}
+    results = []
+    
+    for finding in shellcheck_results:
+        rule_id = f"SC{finding.get('code', '0000')}"
+        
+        # ルール情報を追加
+        if rule_id not in rules_map:
+            rules_map[rule_id] = {
+                "id": rule_id,
+                "shortDescription": {
+                    "text": finding.get('message', 'ShellCheck finding')
+                },
+                "fullDescription": {
+                    "text": finding.get('message', 'ShellCheck finding')
+                },
+                "helpUri": f"https://www.shellcheck.net/wiki/{rule_id}",
+                "properties": {
+                    "category": "security"
+                }
+            }
+        
+        # レベルをSARIFレベルに変換
+        level_map = {
+            "error": "error",
+            "warning": "warning", 
+            "info": "note",
+            "style": "note"
+        }
+        level = level_map.get(finding.get('level', 'warning'), 'warning')
+        
+        # 結果を追加
+        result = {
+            "ruleId": rule_id,
+            "level": level,
+            "message": {
+                "text": finding.get('message', 'ShellCheck finding')
+            },
+            "locations": [
+                {
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": finding.get('file', 'unknown')
+                        },
+                        "region": {
+                            "startLine": finding.get('line', 1),
+                            "startColumn": finding.get('column', 1),
+                            "endLine": finding.get('endLine', finding.get('line', 1)),
+                            "endColumn": finding.get('endColumn', finding.get('column', 1))
+                        }
+                    }
+                }
+            ]
+        }
+        results.append(result)
+    
+    # ルールをツールドライバーに追加
+    sarif_report["runs"][0]["tool"]["driver"]["rules"] = list(rules_map.values())
+    sarif_report["runs"][0]["results"] = results
+    
+    # SARIF結果を出力
+    with open(output_file, 'w') as f:
+        json.dump(sarif_report, f, indent=2)
+    
+    print(f"Converted {len(results)} findings to SARIF format")
+
+if __name__ == "__main__":
+    convert_shellcheck_to_sarif("shellcheck-results.json", "shellcheck.sarif")
+EOF
+            
+            python convert_to_sarif.py
+          else
+            echo "シェルスクリプトファイルが見つかりませんでした"
+            # 空のSARIFファイルを作成
+            cat > shellcheck.sarif << 'EOF'
+{
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "ShellCheck",
+          "version": "0.10.0"
+        }
+      },
+      "results": []
+    }
+  ]
+}
+EOF
+          fi
+
+      - name: SARIF結果をアップロード
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: shellcheck.sarif
+          category: shell-security


### PR DESCRIPTION
## 🔒 実現される価値

リポジトリルール要件を満たすCode Scanningを設定し、**Python + シェルスクリプトの包括的セキュリティ監視体制**を確立します。

## 🚀 主要な機能

### 1. CodeQL（Python）
- **対象**: Pythonコードのセキュリティ脆弱性検出
- **クエリレベル**: security-extended, security-and-quality
- **検出内容**: SQLインジェクション、XSS、パストラバーサル等

### 2. ShellCheck SARIF（シェルスクリプト）
- **対象**: シェルスクリプトのセキュリティ問題検出
- **SARIF統合**: GitHub Code Scanningでの統一表示
- **検出内容**: コマンドインジェクション、クォート問題等

### 3. 実行トリガー
- **プッシュ**: masterブランチへの変更時
- **PR**: プルリクエスト作成・更新時
- **スケジュール**: 毎週月曜日午前2時（UTC）

## 🔧 技術的実装

### ワークフロー構成
```yaml
jobs:
  analyze:          # CodeQL（Python）
  shell-security-scan:  # ShellCheck SARIF
```

### SARIF変換機能
- ShellCheckのJSON出力をSARIF 2.1.0形式に変換
- GitHub Code Scanningとの完全統合
- セキュリティルールの詳細表示

## ✅ リポジトリルール要件
- ✅ CodeQLツールによるCode Scanning
- ✅ セキュリティアラート全対象
- ✅ エラーレベルでのアラート設定

## 🎉 期待される効果
1. **セキュリティ向上**: Python+シェルスクリプトの脆弱性検出
2. **継続的監視**: 週次自動スキャンによる継続的セキュリティ保証
3. **開発効率**: PR時の自動セキュリティチェック
4. **統一管理**: Code Scanningタブでの一元的セキュリティ管理

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>