### PR TITLE
fix: GitHub Actionsワークフローのpyproject.tomlファイルパス問題を修正

### DIFF
--- a/.github/workflows/update_json_data.yml
+++ b/.github/workflows/update_json_data.yml
@@ -41,10 +41,11 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-          cache-dependency-glob: pyproject.toml
+          cache-dependency-glob: main_repo/pyproject.toml
 
       # ステップ4: 依存ライブラリのインストール（本番依存関係のみ）
       - name: 4. 依存ライブラリのインストール
+        working-directory: ./main_repo
         run: |
           uv sync --no-dev
 


### PR DESCRIPTION
## Summary
- GitHub Actionsワークフローで発生していたpyproject.tomlファイルが見つからないエラーを修正
- uvセットアップ時のキャッシュ設定とworking-directoryの設定を修正

## Test plan
- [x] GitHub Actionsワークフローの実行エラーを調査
- [x] pyproject.tomlファイルのパス問題を特定
- [x] cache-dependency-globの設定を修正
- [x] 依存ライブラリインストールステップにworking-directoryを追加
- [ ] 修正後のワークフローが正常に動作することを確認

## Changes Made
1. **cache-dependency-glob設定の修正**
   - `pyproject.toml` → `main_repo/pyproject.toml`
   - ワークフローでリポジトリをmain_repoディレクトリにチェックアウトしているため

2. **working-directoryの追加**
   - 依存ライブラリインストールステップに `working-directory: ./main_repo` を追加
   - uvが正しいディレクトリでpyproject.tomlファイルを参照できるようにした

## 関連Issue
- GitHub Actions実行失敗: https://github.com/9c5s/imas_music_db/actions/runs/16104716645