### PR TITLE
feat: GitHub ActionsでNode.jsからBunに移行

### DIFF
--- a/.github/workflows/update_json_data.yml
+++ b/.github/workflows/update_json_data.yml
@@ -72,18 +72,18 @@ jobs:
             exit 1
           fi
 
-      # ステップ7: Node.js環境をセットアップする
-      - name: 7. Node.js環境のセットアップ
+      # ステップ7: Bun環境をセットアップする
+      - name: 7. Bun環境のセットアップ
         if: steps.generate_json.outputs.JSON_EXISTS == 'true'
-        uses: actions/setup-node@v4
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: '20'  # LTS版のNode.jsを使用
+          bun-version: 'latest'  # 最新版のBunを使用
 
       # ステップ8: PrettierでJSONファイルをフォーマットする
       - name: 8. PrettierでJSONをフォーマット
         if: steps.generate_json.outputs.JSON_EXISTS == 'true'
         run: |
-          npm install -g prettier
+          bun add -g prettier
           prettier --write ${{ steps.generate_json.outputs.json_file_path }}
           echo "💅 JSONファイルがPrettierでフォーマットされました。"
 


### PR DESCRIPTION
## 概要

GitHub ActionsのワークフローでNode.jsの代わりにBunを使用するように移行しました。

## 変更内容

- `actions/setup-node@v4` を `oven-sh/setup-bun@v2` に置き換え
- `npm install -g prettier` を `bun add -g prettier` に置き換え
- コメントと説明文をBunに更新

## 期待される効果

- Bunの高速なランタイムによる実行速度の向上
- パフォーマンスの最適化  
- より効率的なJavaScriptツールの実行

## 技術的詳細

- setup-bunアクション v2（最新のメジャーバージョン）を使用
- Bunの最新バージョンを自動取得
- 既存のPrettierコマンドとの互換性を維持

## テスト状況

- [x] YAMLリンティング: 通過
- [x] ワークフロー構文チェック: 問題なし
- [x] act（ローカルテストツール）での構文検証: 正常

## 影響範囲

変更対象:  のみ
- Node.js関連の設定をBunに変更
- 他のワークフローやプロジェクト設定への影響なし

Fixes #33