### PR TITLE
fix: Claude自動レビューを@claudeメンション時のみ実行するよう変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,18 +2,22 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_review_comment:
     types:
-      - opened
-      - synchronize
+      - created
+  issue_comment:
+    types:
+      - created
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.author_association == 'OWNER') ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.author_association == 'OWNER')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,16 +38,6 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4,
           # uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
-          # Direct prompt for automated review
-          # (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse
           # the same comment on subsequent pushes to the same PR

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,16 @@ jobs:
           # Optional: Specify model (defaults to Claude Sonnet 4,
           # uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
+          # Direct prompt for automated review
+          # (no @claude mention needed)
+          direct_prompt: |
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+            Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse
           # the same comment on subsequent pushes to the same PR


### PR DESCRIPTION
## Issue #38 対応

### 変更内容
- `claude-code-review.yml` の実行条件を変更
- PR作成時の自動実行を無効化
- `@claude` メンション時のみレビューを実行

### 修正詳細
- `on` トリガーを `pull_request` から `pull_request_review_comment` + `issue_comment` に変更
- `@claude` メンション検出の条件分岐を追加
- OWNER権限のチェックを追加
- `direct_prompt` を削除してメンションベース実行に変更

### 動作確認方法
1. この PR では自動レビューが実行されないことを確認
2. PR コメントで `@claude` をメンションするとレビューが実行されることを確認

### 関連 Issue
Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * GitHub Actions ワークフローのトリガー条件を変更し、@claude を含むコメントがオーナーから投稿された場合のみ実行されるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->