### PR TITLE
feat: PrettierをbunxでGlobal Install無しで実行

### DIFF
--- a/.github/workflows/update_json_data.yml
+++ b/.github/workflows/update_json_data.yml
@@ -83,8 +83,7 @@ jobs:
       - name: 8. PrettierでJSONをフォーマット
         if: steps.generate_json.outputs.JSON_EXISTS == 'true'
         run: |
-          bun add -g prettier
-          prettier --write ${{ steps.generate_json.outputs.json_file_path }}
+          bunx prettier --write ${{ steps.generate_json.outputs.json_file_path }}
           echo "💅 JSONファイルがPrettierでフォーマットされました。"
 
       # ステップ9: 生成されたデータをコミットするブランチ(data)をチェックアウトする

--- a/.github/workflows/update_json_data.yml
+++ b/.github/workflows/update_json_data.yml
@@ -83,7 +83,8 @@ jobs:
       - name: 8. PrettierでJSONをフォーマット
         if: steps.generate_json.outputs.JSON_EXISTS == 'true'
         run: |
-          bunx prettier --write ${{ steps.generate_json.outputs.json_file_path }}
+          bunx prettier --write \
+            ${{ steps.generate_json.outputs.json_file_path }}
           echo "💅 JSONファイルがPrettierでフォーマットされました。"
 
       # ステップ9: 生成されたデータをコミットするブランチ(data)をチェックアウトする


### PR DESCRIPTION
## 変更内容
- update_json_data.ymlでPrettierの実行方法をbunxに変更
- グローバルインストール（bun add -g prettier）を削除
- より効率的でクリーンな実行環境を提供

## 効果
- 必要な時だけPrettierをダウンロード・実行
- 実行時間の短縮
- 依存関係管理の簡素化

## 変更詳細
### 変更前:
```yaml
bun add -g prettier
prettier --write ${{ steps.generate_json.outputs.json_file_path }}
```

### 変更後:
```yaml
bunx prettier --write ${{ steps.generate_json.outputs.json_file_path }}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * ワークフロー内でのJSONファイルのフォーマット方法を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->