### PR TITLE
fix: GitHub Actions非推奨警告を修正

### DIFF
--- a/.github/workflows/update_json_data.yml
+++ b/.github/workflows/update_json_data.yml
@@ -138,6 +138,7 @@ jobs:
         if: steps.commit_push.outputs.committed == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.commit_push.outputs.tag_name }}
           name: データ更新 (${{ steps.commit_push.outputs.tag_name }})
           body: |
@@ -147,5 +148,3 @@ jobs:
           # dataブランチの最新コミットからリリースを作成
           target_commitish: data
           files: ./data_repo/imas_music_db.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
GitHub Actionsワークフローで発生していた非推奨警告アノテーションを修正しました。

## 変更内容
- `actions/create-release@v1` と `actions/upload-release-asset@v1` を `softprops/action-gh-release@v2` に置き換え
- リリース作成とアセットアップロードを1つのステップに統合
- `set-output` コマンドの非推奨警告を解消

## 影響
- 4つの非推奨警告アノテーションが解消されます
- より安定したリリース処理が実現されます
- 将来的な互換性が確保されます

## テスト計画
- [x] YAMLフォーマットチェック (`yamlfix`)
- [x] YAMLリンティングチェック (`yamllint`)
- [ ] ワークフロー実行確認（マージ後の自動実行で確認）

## 関連リンク
- 対象のワークフロー実行: https://github.com/9c5s/imas_music_db/actions/runs/16255029686

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * リリース作成とJSONアセットのアップロード手順を1つのステップに統合し、ワークフローを簡素化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->