### PR TITLE
Claude設定ディレクトリを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ credentials.json
 token.json
 
 # Claude instructions
+.claude/


### PR DESCRIPTION
## 概要
Claude設定ディレクトリ（`.claude/`）を`.gitignore`に追加し、リポジトリから除外するよう設定

## 変更内容
- `.gitignore`に`.claude/`エントリを追加
- Claude Code用の設定ファイルがgit管理から除外される

## 目的
- プライベートなClaude設定をリポジトリに含めない
- 個人設定の漏洩を防止
- クリーンなリポジトリ管理の維持