### PR TITLE
Gitフック自動化機能の追加と改行コード統一

### DIFF
--- a/config/yamllint.yml
+++ b/config/yamllint.yml
@@ -90,9 +90,9 @@ rules:
   new-line-at-end-of-file:
     level: error
 
-  # 改行文字をプラットフォーム適応型に設定（Windows/Unix対応）
+  # 改行文字をUnix形式（LF）に統一
   new-lines:
-    type: platform
+    type: unix
     level: error
 
   # コメントの前のスペースを厳格に要求

--- a/config/yamllint.yml
+++ b/config/yamllint.yml
@@ -90,6 +90,11 @@ rules:
   new-line-at-end-of-file:
     level: error
 
+  # 改行文字をプラットフォーム適応型に設定（Windows/Unix対応）
+  new-lines:
+    type: platform
+    level: error
+
   # コメントの前のスペースを厳格に要求
   comments:
     min-spaces-from-content: 2

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,7 +6,7 @@ pre-commit:
     # Python品質チェック
     python-lint:
       glob: "*.py"
-      run: uv run ruff check --config config/ruff.toml {staged_files}
+      run: uv run ruff check --fix --config config/ruff.toml {staged_files}
       stage_fixed: true
     python-format:
       glob: "*.py"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,58 @@
+---
+# Lefthook設定ファイル - Git hookによる自動品質チェック
+pre-commit:
+  parallel: true
+  commands:
+    # Python品質チェック
+    python-lint:
+      glob: "*.py"
+      run: uv run ruff check --config config/ruff.toml {staged_files}
+      stage_fixed: true
+    python-format:
+      glob: "*.py"
+      run: uv run ruff format --config config/ruff.toml {staged_files}
+      stage_fixed: true
+
+    # YAML品質チェック
+    yaml-lint:
+      glob: "*.{yaml,yml}"
+      run: uv run yamllint -c config/yamllint.yml {staged_files}
+    yaml-format:
+      glob: "*.{yaml,yml}"
+      run: uv run yamlfix -c config/yamlfix.toml {staged_files}
+      stage_fixed: true
+
+    # シェルスクリプト品質チェック
+    shell-lint:
+      glob: "*.sh"
+      run: uv run shellcheck --rcfile=config/.shellcheckrc {staged_files}
+    shell-format:
+      glob: "*.sh"
+      run: uv run shfmt -i 2 -p -s -ci -sr -fn -w {staged_files}
+      stage_fixed: true
+
+pre-push:
+  parallel: true
+  commands:
+    # より包括的な品質チェック（全ファイル対象）
+    python-check-all:
+      run: uv run ruff check --config config/ruff.toml .
+    yaml-check-all:
+      run: uv run yamllint -c config/yamllint.yml .
+    shell-check-all:
+      run: |
+        if ls ./*.sh 1> /dev/null 2>&1; then
+          uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
+        fi
+        if ls scripts/*.sh 1> /dev/null 2>&1; then
+          uv run shellcheck --rcfile=config/.shellcheckrc scripts/*.sh
+        fi
+
+# メッセージ設定
+colors: true
+no_tty: false
+
+# Gitのカラー出力を有効化
+output:
+  - meta
+  - summary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,5 @@ dev = [
     "google-auth-stubs>=0.3.0",
     "google-api-python-client-stubs>=1.29.0",
     "pyright>=1.1.403",
+    "lefthook>=1.7.22",
 ]
-


### PR DESCRIPTION
## 概要
Gitフック自動化機能を追加し、YAMLファイルの改行コードをLFに統一

## 変更内容
- lefthook.ymlを追加してpre-commit/pre-pushフックを設定
- Python・YAML・シェルスクリプトの品質チェックを自動化  
- yamllint設定で改行コードをUnix形式（LF）に統一
- pyproject.tomlでlefthook依存関係を追加
- CLAUDE.mdに型チェック・Gitフック自動化の手順を追記
- YAMLファイルの改行コードをLFに変換

## テストプラン
- [ ] pre-commitフックが正常に動作することを確認
- [ ] pre-pushフックが正常に動作することを確認
- [ ] YAMLファイルのリンティングが通ることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Pyrightによる型チェックや新しいCI/CDワークフロー、LefthookによるGitフック自動化、外部YAML設定ファイルの導入など、開発・自動化・設定管理に関する内容を追記しました。

* **新機能**
  * LefthookによるGitフック自動化を追加し、コミット・プッシュ時に自動でコード品質チェックと修正を実行するようになりました。
  * 新しい型チェックコマンドやタスクを追加しました。
  * 新しいYAML設定ファイルとPyright設定ファイルを追加しました。
  * GitHub ActionsにClaude Code連携ワークフローを導入しました。

* **スタイル**
  * YAMLファイルの改行コードをLFに統一するlintルールを追加しました。

* **チョア**
  * 開発用依存関係としてLefthookを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->