### PR TITLE
chore: .gitignoreの更新とコーディング規約のドキュメント整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ token.json
 
 # Claude instructions
 .claude/
+
+#Serena MCP
+.serena/

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,5 @@ token.json
 # Claude instructions
 .claude/
 
-#Serena MCP
+# Serena MCP
 .serena/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -283,7 +283,7 @@ imas_music_db/
 - 全ファイル対象の品質チェック
 - Ruff・yamllint・ShellCheckによる最終検証
 
-**セットアップ**: 
+**セットアップ**:
 ```bash
 # lefthookのインストールと有効化
 uv run lefthook install
@@ -315,17 +315,3 @@ uv run lefthook install
 ```
 https://raw.githubusercontent.com/9c5s/imas_music_db/data/imas_music_db.json
 ```
-
-## コーディング規約
-
-- コメントは日本語で記述する
-- コメントは「だ・である調」で記述する
-- コメントに全角記号を使用しない
-- エラーハンドリングを適切に行う
-- セキュリティを考慮したコーディングを行う
-- コードの可読性を重視する
-- 関数やメソッドは単一責任の原則に従う
-- 命名規則は一貫性を持たせる
-- コードの再利用性を考慮する
-- ドキュメントを適切に記述する
-- パフォーマンスを意識する


### PR DESCRIPTION
## 概要

本プルリクエストでは、以下の2つの対応を行った。

1.  `.gitignore`に`.serena/`ディレクトリを追加し、関連ファイルをGitの管理対象から除外した。
2.  `CLAUDE.md`に記載されていたコーディング規約を、より適切な場所へ移動するために削除した。

## 変更内容

- **.gitignoreの更新** (`e47c44d`)
  - Serena関連のファイルが誤ってコミットされるのを防ぐため、`.serena/`を無視リストに追加した。

- **コーディング規約の移動** (`ee7ef9d`)
  - プロジェクト全体のルールであるコーディング規約を、AIモデル固有のドキュメント(`CLAUDE.md`)から分離した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- ドキュメント
  - 「コーディング規約」セクションを削除し、説明を簡素化。セットアップ見出しなどの体裁を統一し、末尾改行を追加して読みやすさを向上。

- チョア
  - 開発用ディレクトリ（Serena MCP）を無視対象に追加し、既存の無視設定の体裁を微調整。ユーザー機能への影響はなし。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->