### PR TITLE
CLAUDE.mdとscripts.shを実態に合わせて修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,11 +174,11 @@ imas_music_db/
 
 ### メインコンポーネント
 
-1. **GoogleApiService** (`sheet_to_json.py:159-187`)
+1. **GoogleApiService** (`sheet_to_json.py`)
    - Google Sheets APIの認証とサービス初期化を管理
    - スコープ: `spreadsheets.readonly`
 
-2. **SheetProcessor** (`sheet_to_json.py:190-`)
+2. **SheetProcessor** (`sheet_to_json.py`)
    - スプレッドシートの生データを設定に基づいて処理・整形
    - IDの降順ソート、配列フィールドの統合処理
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,13 +62,13 @@ uv run yamlfix -c config/yamlfix.toml .
 #### シェルスクリプト（厳格ルール）
 ```bash
 # ShellCheckによるリンティング（全ルール有効）
-uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh scripts/*.sh
+uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
 
 # shfmtによるフォーマット（POSIX準拠）
-uv run shfmt -i 2 -p -s -ci -sr -fn -w ./*.sh scripts/*.sh
+uv run shfmt -i 2 -p -s -ci -sr -fn -w ./*.sh
 
 # フォーマットチェック（差分表示）
-uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh scripts/*.sh
+uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh
 ```
 
 **厳格ルール詳細:**
@@ -80,15 +80,6 @@ uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh scripts/*.sh
 - **セキュリティ**: 変数クォート・終了コード検証
 
 ### 開発タスク（uvベース）
-
-#### ワンコマンドでPR作成・監視
-```bash
-# PR自動作成と監視（推奨）
-./scripts.sh pr
-
-# または直接実行
-uv run python scripts/auto_pr.py
-```
 
 #### コード品質チェック
 ```bash
@@ -134,14 +125,8 @@ uv run python scripts/auto_pr.py
 # メインスクリプト実行
 ./scripts.sh run
 
-# 最新PRの監視
-./scripts.sh monitor
-
 # 一時ファイル削除
 ./scripts.sh clean
-
-# ワークフローエラーの自動修正
-uv run python scripts/fix_workflow_errors.py
 ```
 
 ### 認証設定
@@ -165,12 +150,7 @@ imas_music_db/
 │   ├── .editorconfig      # shfmtフォーマッター設定
 │   ├── pyrightconfig.json # Pyright型チェッカー設定
 │   └── sheet_config.yml   # スプレッドシート設定（外部分離）
-├── scripts/               # 自動化スクリプト
-│   ├── auto_pr.py         # PR作成・監視自動化
-│   ├── fix_workflow_errors.py # ワークフローエラー自動修正
-│   └── monitor_pr.py      # PR監視
 ├── .github/workflows/     # GitHub Actions
-│   ├── code_quality.yml   # コード品質チェック（型チェック含む）
 │   ├── update_json_data.yml # データ更新自動化
 │   └── claude.yml         # Claude Code連携
 ├── sheet_to_json.py       # メインスクリプト
@@ -194,23 +174,13 @@ imas_music_db/
 
 ### メインコンポーネント
 
-1. **GoogleApiService** (`sheet_to_json.py:113-140`)
-   - Google Drive API・Sheets APIの認証とサービス初期化を管理
-   - スコープ: `drive`, `spreadsheets`
+1. **GoogleApiService** (`sheet_to_json.py:159-187`)
+   - Google Sheets APIの認証とサービス初期化を管理
+   - スコープ: `spreadsheets.readonly`
 
-2. **SheetCopier** (`sheet_to_json.py`)
-   - スプレッドシートの一時コピー作成・削除を管理
-   - コンテキストマネージャーとして実装（自動クリーンアップ）
-
-3. **SheetProcessor** (`sheet_to_json.py:142-`)
+2. **SheetProcessor** (`sheet_to_json.py:190-`)
    - スプレッドシートの生データを設定に基づいて処理・整形
    - IDの降順ソート、配列フィールドの統合処理
-
-4. **WorkflowErrorFixer** (`scripts/fix_workflow_errors.py`)
-   - GitHub Actionsのコード品質チェックエラーを自動修正
-   - Ruffフォーマット・リンティングエラーの自動修正
-   - YAMLエラーの自動修正
-   - 修正のコミット・プッシュと結果確認
 
 ### データフロー
 
@@ -251,18 +221,7 @@ imas_music_db/
    - dataブランチに変更をコミット・プッシュ
    - 新しいリリースを作成・JSONファイルを添付
 
-### コード品質チェックワークフロー
-
-プルリクエスト作成時に以下のワークフローが自動実行されます：
-
-**`code_quality.yml`**: 統合コード品質チェック（PRコメント付き）
-- **Pythonファイル**: Ruffリンティング・フォーマットチェック・Pyright型チェック
-- **YAMLファイル**: yamllintチェック
-- **シェルスクリプト**: ShellCheck・shfmtチェック
-- チェック結果をPRにコメントとして投稿
-- 統計情報と修正方法の表示
-- GitHub Actions UI上でのエラー表示
-- 4言語統合による包括的な品質保証（型安全性含む）
+### Claude Code連携ワークフロー
 
 **`claude.yml`**: Claude Code連携ワークフロー
 - PRコメント・イシュー・レビューでの@claudeメンション対応
@@ -307,7 +266,7 @@ uv run lefthook install
 
 - Workload Identity連携による認証
 - 必要なシークレット: `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`
-- APIスコープ: Google Drive API, Google Sheets API
+- APIスコープ: Google Sheets API（読み取り専用）
 
 ## データ配信
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,9 +44,6 @@ pre-push:
         if ls ./*.sh 1> /dev/null 2>&1; then
           uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
         fi
-        if ls scripts/*.sh 1> /dev/null 2>&1; then
-          uv run shellcheck --rcfile=config/.shellcheckrc scripts/*.sh
-        fi
 
 # メッセージ設定
 colors: true

--- a/scripts.sh
+++ b/scripts.sh
@@ -24,13 +24,10 @@ show_help()
   echo "  type-check     - Pyrightによる型チェック"
   echo "  test           - 全てのコード品質チェック（型チェック含む）"
   echo "  run            - メインスクリプトの実行"
-  echo "  pr             - PR作成と自動監視"
-  echo "  monitor        - 最新PRの監視"
   echo "  clean          - 一時ファイルの削除"
   echo "  help           - このヘルプを表示"
   echo ""
   echo "例:"
-  echo "  ./scripts.sh pr        # PR作成と監視"
   echo "  ./scripts.sh test      # コード品質チェック"
   echo "  ./scripts.sh shell-check  # シェルスクリプト品質チェック"
   echo "  ./scripts.sh run       # メインスクリプト実行"
@@ -70,18 +67,18 @@ case "${1:-help}" in
     ;;
   "shell-lint")
     echo "🔍 シェルスクリプトをリンティング中..."
-    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
     ;;
   "shell-format")
     echo "💅 シェルスクリプトをフォーマット中..."
-    uv run shfmt -i 2 -p -s -ci -sr -fn -w ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shfmt -i 2 -p -s -ci -sr -fn -w ./*.sh
     ;;
   "shell-check")
     echo "🧪 シェルスクリプト品質チェックを実行中..."
     echo "--- シェルスクリプトリンティング ---"
-    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
     echo "--- シェルスクリプトフォーマットチェック ---"
-    uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh
     echo "✅ シェルスクリプト品質チェックが完了しました"
     ;;
   "type-check")
@@ -98,22 +95,14 @@ case "${1:-help}" in
     echo "--- YAMLリンティング ---"
     uv run yamllint -c config/yamllint.yml .
     echo "--- シェルスクリプトリンティング ---"
-    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shellcheck --rcfile=config/.shellcheckrc ./*.sh
     echo "--- シェルスクリプトフォーマットチェック ---"
-    uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh scripts/*.sh 2> /dev/null || echo "⚠️  一部のシェルスクリプトファイルが見つかりませんでした"
+    uv run shfmt -i 2 -p -s -ci -sr -fn -d ./*.sh
     echo "✅ 全てのコード品質チェックが完了しました"
     ;;
   "run")
     echo "🚀 メインスクリプトを実行中..."
     uv run python sheet_to_json.py
-    ;;
-  "pr")
-    echo "🚀 PR作成と監視を開始..."
-    uv run python scripts/auto_pr.py
-    ;;
-  "monitor")
-    echo "🔍 最新PRを監視中..."
-    uv run python scripts/monitor_pr.py
     ;;
   "clean")
     echo "🧹 一時ファイルを削除中..."


### PR DESCRIPTION
## 概要

CLAUDE.mdの記述と実際のリポジトリ構成に乖離があったため、実態に合わせて修正。

## 変更内容

### CLAUDE.md
- 削除済みファイル・ディレクトリの記述を除去（`scripts/` ディレクトリ、`code_quality.yml`）
- 削除済みクラスの記述を除去（`SheetCopier`、`WorkflowErrorFixer`）
- `GoogleApiService` の行番号（`113-140` → `159-187`）とAPIスコープ（`drive, spreadsheets` → `spreadsheets.readonly`）を修正
- `SheetProcessor` の行番号（`142-` → `190-`）を修正
- 存在しないコマンド（`pr`、`monitor`）・スクリプト参照を削除
- シェルスクリプトコマンド例から存在しない `scripts/*.sh` パスを削除

### scripts.sh
- 存在しない `scripts/auto_pr.py` を参照する `pr` コマンドを削除
- 存在しない `scripts/monitor_pr.py` を参照する `monitor` コマンドを削除
- シェルスクリプト系コマンドから存在しない `scripts/*.sh` パス参照を削除
- 不要なエラー抑制（`2> /dev/null || echo "⚠️ ..."` ）を除去

## テスト計画
- [x] `./scripts.sh help` で削除したコマンドが表示されないことを確認
- [x] CLAUDE.mdの記述が実ファイルと一致することを確認